### PR TITLE
Use max_jobs value from run config

### DIFF
--- a/emitrdn_wrapper.py
+++ b/emitrdn_wrapper.py
@@ -81,6 +81,7 @@ def main():
            f"--mode {runconfig['instrument_mode']}",
            f"--level {runconfig['level']}",
            f"--log_file {log_path}",
+           f"--max_jobs {runconfig['max_jobs']}",
            runconfig["raw_img_path"],
            runconfig["dark_img_path"],
            l1b_config_path,


### PR DESCRIPTION
Added `max_jobs` argument, from run config,  to `emitrdn.py` call.

Depends on https://github.com/emit-sds/emit-main/pull/82