### PR TITLE
OSF gaussian interpolation optimization

### DIFF
--- a/emitrdn.py
+++ b/emitrdn.py
@@ -20,7 +20,7 @@ sys.path.append(my_directory + '/utils/')
 
 from fpa import FPA, frame_embed, frame_extract
 from fixbad import fix_bad
-from fixosf import fix_osf, fix_osf_gaussian
+from fixosf import fix_osf, fix_osf_gaussian, precalc_fix_osf_gaussian_variables
 from fixlinearity import fix_linearity
 from fixscatter import fix_scatter
 from fixghost import fix_ghost
@@ -115,10 +115,16 @@ class Config:
         # file is defined, we are using method #2.  Read in the file.
         if hasattr(fpa,'osf_seam_interpolation_file'):
             d = loadmat(fpa.osf_seam_interpolation_file)
-            self.radiance_mean = np.squeeze(d['radiance_mean'])
-            self.radiance_covariance = d['radiance_covariance']
+            radiance_mean = np.squeeze(d['radiance_mean'])
+            radiance_covariance = d['radiance_covariance']
+            
+            self.precalc_osf = precalc_fix_osf_gaussian_variables(fpa, 
+                                               radiance_mean,
+                                               radiance_covariance,
+                                               )
+            self.run_gaussian_osf = True
         else:
-            self.radiance_mean = None
+            self.run_gaussian_osf = False
 
         # zero offset perturbation
         self.zero_offset = np.zeros((fpa.native_rows, fpa.native_columns))
@@ -213,7 +219,7 @@ def calibrate_raw(frame, fpa, config):
         # There are two ways to fix OSF seams.  The first one is the
         # traditional way, which is applied to unclipped, unflipped (long-to-short)
         # FPA data.
-        if config.radiance_mean is None:
+        if not config.run_gaussian_osf:
             frame = fix_osf(frame, fpa)
 
         # Catch NaNs
@@ -236,9 +242,8 @@ def calibrate_raw(frame, fpa, config):
 
     # If we are using the statistical prediction method for fixing the  OSF seam,
     # we apply that approach to clipped data
-    if config.radiance_mean is not None:
-        frame = fix_osf_gaussian(frame, fpa, config.radiance_mean,
-            config.radiance_covariance)
+    if config.run_gaussian_osf:
+        frame = fix_osf_gaussian(frame, config.precalc_osf)
 
     # Mirror image
     if hasattr(fpa, 'flip_horizontal') and fpa.flip_horizontal:
@@ -261,7 +266,7 @@ def main():
     parser.add_argument('--level', default='DEBUG',
             help='verbosity level: INFO, ERROR, or DEBUG')
     parser.add_argument('--log_file', type=str, default=None)
-    parser.add_argument('--max_jobs', type=int, default=40)
+    parser.add_argument('--max_jobs', type=int, default=64)
     parser.add_argument('input_file', default='')
     parser.add_argument('dark_file', default = None)
     parser.add_argument('config_file', default='')

--- a/utils/fixosf.py
+++ b/utils/fixosf.py
@@ -17,7 +17,7 @@ from numba import jit
 from math import pow
 from fpa import FPA
 from scipy.interpolate import interp1d
-from isofit.core.common import conditional_gaussian, svd_inv 
+from isofit.core.common import svd_inv 
 import subprocess
 
 

--- a/utils/fixosf.py
+++ b/utils/fixosf.py
@@ -17,7 +17,7 @@ from numba import jit
 from math import pow
 from fpa import FPA
 from scipy.interpolate import interp1d
-from isofit.core.common import conditional_gaussian
+from isofit.core.common import conditional_gaussian, svd_inv 
 import subprocess
 
 
@@ -30,30 +30,47 @@ def find_header(infile):
     raise FileNotFoundError('Did not find header file')
 
 
-def fix_osf_gaussian(frame, fpa, mu, C):
-    fixed = frame.copy()
+def precalc_fix_osf_gaussian_variables(fpa, mu, C):
 
-    if len(fpa.osf_seam_interpolation_edges)==0:
-        return fixed
+    n_rows = fpa.last_distributed_row - fpa.first_distributed_row + 1
 
     # Calculate indices for inferred portion and remainder 
-    window = []
+    mask = np.ones(n_rows, dtype=bool)
     for positions in fpa.osf_seam_interpolation_edges:
-        window.extend(np.arange(positions[0]+1,positions[1]))
-    remain = [q for q in np.arange(frame.shape[0]) if q not in window]
+        mask[positions[0]+1:positions[1]] = False
+    remain = np.where(mask)[0]
+    window = np.where(~mask)[0]
+
+    w = window[:, None]
+    r = remain[:, None]
+    C11 = C[r, r.T]
+    C21 = C[w, r.T]
+    Cinv = svd_inv(C11)
+    M = C21 @ Cinv
+
+    return {
+        "window": window,
+        "remain": remain,
+        "M": M,
+        "mu_window": mu[window],
+        "mu_remain": mu[remain]
+    }
+
+def fix_osf_gaussian(frame, precomp):
+    fixed = frame.copy()
+    window = precomp["window"]
+    remain = precomp["remain"]
+    M = precomp["M"]
+    mu_window = precomp["mu_window"]
+    mu_remain = precomp["mu_remain"]
 
     # Perform inference for each spectrum independently
     # mean mu and covariance C are for normalized radiances
-    for col in range(fixed.shape[1]):
-        rdn = frame[:,col]
-        z = np.linalg.norm(rdn)
-        normed = rdn / z
-        pred,_ = conditional_gaussian(mu, C, window, remain, 
-            normed[remain])
-        fixed[window,col] = (pred * z)
-
+    z = np.linalg.norm(frame, axis=0)
+    normed = frame / z
+    pred = mu_window[:, None] + M @ (normed[remain, :] - mu_remain[:, None])
+    fixed[window, :] = pred * z
     return fixed
-
 
 def fix_osf(frame, fpa):
     fixed = frame.copy()


### PR DESCRIPTION
Optimized Gaussian OSF interpolation.

- Precomputed variables during config loading
- Vectorized operations
- Removed unused calculations

**Per frame runtime comparisons (M4 mac):**

<img width="1621" height="1116" alt="fix_osf_runtime_compare" src="https://github.com/user-attachments/assets/a93dbd43-81a5-4cb5-9ebb-2fc5feecd487" />

**Per-acquisition L1B Calibrate w/ optimized OSF runtime on cluster (64 cores):**

<img width="406" height="408" alt="Screenshot 2025-10-02 at 10 30 10 AM" src="https://github.com/user-attachments/assets/239781d5-1fa7-4c4a-8ac0-c47dd0409d75" />

**Comparison of radiance at OSF seam across ~128 acquisitions original vs optimized code (Mean diff: −1.841 × 10⁻⁶ )**

<img width="2138" height="1634" alt="emit_osf_opt_diff" src="https://github.com/user-attachments/assets/19e22134-875b-4af7-ac47-a4746f9fa199" />

